### PR TITLE
Added folder dialogs at macro startup

### DIFF
--- a/globalVars.py
+++ b/globalVars.py
@@ -19,12 +19,6 @@ from __future__ import division # allows floating point division from integersim
 
 reloadClasses = False
 test = None
-
-#Change the following to the path to the directory that will hold your printer designs
-#Unless using windows, then use \\ instead of either of the above
-#Make sure to use forward slashes like this / and not back slashes like this \ 
-freecadDir = "/Path/To/FreeCAD/"
-printerDir = "/Path/To/Store/3D/Files/"
  
 #Output Options
 level = 2
@@ -74,6 +68,8 @@ mountToFrameDia = 4.12 #Actual diameter of holes that are used to mount items to
 mountToFrameHeadDia = 6         #Actual head diameter of bolts used to mount items to the frame.
 mountToFrameHeadThickness = 3   #Actual head Thickness of bolts used to mount items to the frame.
 mountToPrintedPadding = 3	#ADVANCED the minimum distance between the edge of a hole and the edge of the part                                                          
+mountToPrintedNutFaceToFace = 3 #TODO no idea what this is for but it is apparently needed by makePrinter
+mountToPrintedNutThickness = 3  #TODO no idea what this is for but it is apparently needed by leadScrewCoupler
 printedToFrameDia = None 	#CALCULATED The adjusted diameter for printed parts that will be mounted to the frame.                                                      
 printedToFrameHeadDia = None    #CALCULATED The adjusted diameter for printed parts that will be mounted to the frame.                                                     
 printedToPrintedDia = None 	#CALCULATED The adjusted diameter for printed parts mounted to other printed parts or to non frame parts                                    
@@ -456,6 +452,10 @@ invertEDirection = False #ADVANCED Inverts the Extruder stepper motor
 #Slic3r Variables                                                                                                                                                         
 slic3r = False #Slice or nah?                                                                                                                                             
 slic3rVars = ""                                                                                                                                                           
-                                                                                                                                                         
+
+gauge = 28 #Gauge of wire to be used as heating wire on the build plate
+amperage = 10 #ADVANCED Only change this if you know what you are doing, this is a very easy way to turn your electronics in to fuel
+voltage = 12 #ADVANCED Only change this if you know what you are doing
+
 #Zip Variables                                                                                                                                            
 zipName = "Printer_Files" #Name of zip file                 

--- a/heatedbed.py
+++ b/heatedbed.py
@@ -42,10 +42,16 @@ def design():
 
     # Make dateString and add it to the directory string
     date = datetime.date.today().strftime("%m_%d_%Y")
-    printerDir = gv.printerDir+"Printer_"+date+"/"
+    printerDir = gv.printerDir+"Printer_"+date
 
     filename = os.path.join(printerDir, 'Parts', 'Heated Bed Wire Diagram.svg')
     print filename
+    if not os.path.exists(os.path.dirname(filename)):
+        try:
+            os.makedirs(os.path.dirname(filename))
+        except OSError as exc: # Guard against race condition
+            if exc.errno != errno.EEXIST:
+                raise
     svg = open(filename, 'w')
     svg.write('<svg width="'+printableWidth+'mm" height="'+printableLength+'mm">')
     svg.write('<circle cx="15mm" cy="15mm" r="1.5mm" fill="white" stroke="black" stroke-width=".5mm" />')

--- a/macro.FCMacro
+++ b/macro.FCMacro
@@ -15,7 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with Retr3d.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-import os
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-execfile(os.path.dirname(os.path.abspath(__file__))+'/makePrinter.py')
+import sys, os, subprocess
+from PySide import QtGui
+
+retr3d_path = QtGui.QFileDialog.getExistingDirectory(None,"Please indicate the location of your Retr3D folder")
+output_path = QtGui.QFileDialog.getExistingDirectory(None,"Now please choose a folder to save output files")
+
+if retr3d_path and output_path:
+    sys.path.append(retr3d_path)
+    import globalVars as gv
+    gv.printerDir = output_path + os.sep
+    import makePrinter
+else:
+    print "Aborting."

--- a/makePrinter.py
+++ b/makePrinter.py
@@ -23,11 +23,7 @@ import sys
 import platform
 import subprocess
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-
 import globalVars as gv
-
-sys.path.append(gv.freecadDir)
 
 try:
     import utilityFunctions as uf
@@ -122,10 +118,6 @@ def makePrinter():
             finally:
                 uf.info("FreeCAD Version 0." + App.Version()[1] + " Revision " + App.Version()[2],
                         "FreeCAD Version 0." + App.Version()[1] + " Revision " + App.Version()[2], gv.level, source)
-
-
-
-
 
 
     # import Part modules


### PR DESCRIPTION
A couple of improvements to reduce the installation procedure:
- Two dialogs now pop up at macro start to choose retr3d and output paths
- No more hardcoded paths
- Fixed apparently missing values in global vars

With these changes, one is now able to simply download or clone the repo, copy the macro to the FreeCAD macros folder, and launch the macro. Hopefully all this is fully cross-platform.

In a next pull request, I propose to make retr3d compatible with https://github.com/FreeCAD/FreeCAD-addons (rename the macro, and store the two folder paths in the FreeCAD preferences) if it's okay with you guys, we can then add it to the addons list
