### PR TITLE
Compatibility with FreeCAD-addons repository

### DIFF
--- a/retr3d.FCMacro
+++ b/retr3d.FCMacro
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 # Copyright 2015 Matthew Rogge and Michael Uttmark
 # 
 # This file is part of Retr3d.
@@ -15,16 +18,30 @@
 # You should have received a copy of the GNU General Public License
 # along with Retr3d.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys, os, subprocess
+import sys, os, FreeCAD
 from PySide import QtGui
 
-retr3d_path = QtGui.QFileDialog.getExistingDirectory(None,"Please indicate the location of your Retr3D folder")
-output_path = QtGui.QFileDialog.getExistingDirectory(None,"Now please choose a folder to save output files")
+# retriving stored paths in FreeCAD preferences
+param = FreeCAD.ParamGet('User parameter:Plugins/retr3d')
+retr3d_path = param.GetString('destination','')
+output_path = param.GetString('output','')
+
+if retr3d_path:
+    print "Using retr3d path: ",retr3d_path," from Tools->Edit parameters->Plugins->retr3d->destination"
+else:
+    retr3d_path = QtGui.QFileDialog.getExistingDirectory(None,"Please indicate the location of your Retr3D folder")
+    
+if output_path:
+    print "Using output path: ",retr3d_path," from Tools->Edit parameters->Plugins->retr3d->output"
+else:
+    output_path = QtGui.QFileDialog.getExistingDirectory(None,"Please choose a folder to save output files")
 
 if retr3d_path and output_path:
+    param.SetString('destination',retr3d_path)
+    param.SetString('output',output_path)
     sys.path.append(retr3d_path)
     import globalVars as gv
     gv.printerDir = output_path + os.sep
     import makePrinter
 else:
-    print "Aborting."
+    print "Retr3d or output path not set. Aborting."


### PR DESCRIPTION
Okay, here it is! After this we can add retr3d to the addons list. 
- Renamed the macro to have a unique name
- Stored the retr3d and output paths in FreeCAD preferences
